### PR TITLE
Save and Restore contentInset and scrollIndicatorInsets

### DIFF
--- a/UIViewController+Keyboard.swift
+++ b/UIViewController+Keyboard.swift
@@ -23,7 +23,6 @@ extension UIViewController {
     private struct SingleLineKeyboardResizeKeys {
         static var ScrollViewKey = "single_line_scroll_view_key"
         static var ScrollViewContentInsetsKey = "single_line_content_insets_key"
-        static var ScrollContentInsetsKey = "single_line_content_insets_key"
         static var ScrollIndicatorInsetsKey = "single_line_indicator_insets_key"
     }
     


### PR DESCRIPTION
Previously `contentInset` and `scrollIndicatorInsets` were being overwritten with UIEdgeInsets.zero when hiding the keyboard. This PR saves away the values before the keyboard shows, and restores them on the hide.

I know you forked the original https://github.com/haaakon/SingleLineKeyboardResize, but since yours is more up to date I added a PR to yours :)